### PR TITLE
Return userId from verifyAndDecrypt

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -240,7 +240,12 @@ sipClientFactory.newClient = function (config) {
       console.log('Error parsing decrypted string to user data: ' + e.message);
     }
 
-    return userData;
+    var decryptedPayload = {
+      data: userData,
+      userId: payload.userId
+    };
+
+    return decryptedPayload;
   };
 
   apigClient.exchangeCode = exchangeCode;

--- a/index.js
+++ b/index.js
@@ -151,7 +151,12 @@ sipClientFactory.newClient = function (config) {
       console.log('Error parsing decrypted string to user data: ' + e.message);
     }
 
-    return userData;
+    const decryptedPayload = {
+        data: userData,
+        userId: payload.userId,
+    };
+
+    return decryptedPayload;
   }
   /**
    * Exchange authorization code in the form of a JWT Token for the user data


### PR DESCRIPTION
This change makes the interface of the library comply with the docs, which specify that both the userData and the userId are returned from the call to `exchangeCode ` (See step 5: https://docs.civic.com/api/index.html#GettingStarted)

Expected return response:

```
userData = {
                "data": [
                    {
                        "label": "contact.verificationLevel.CIVIC_0",
                        "value": "contact.verificationLevel.CIVIC_0, true",
                        "isValid": true,
                        "isOwner": true
                    },
                    {
                        "label": "contact.personal.email",
                        "value": "user.test@gmail.com",
                        "isValid": true,
                        "isOwner": true
                    },
                    {
                        "label": "contact.personal.phoneNumber",
                        "value": "+1 555-618-7380",
                        "isValid": true,
                        "isOwner": true
                    }
                ],
                "userId": "36a59d10-6c53-17f6-9185-gthyte22647a"
            }
```

Received response before this fix:

```
[
                    {
                        "label": "contact.verificationLevel.CIVIC_0",
                        "value": "contact.verificationLevel.CIVIC_0, true",
                        "isValid": true,
                        "isOwner": true
                    },
                    {
                        "label": "contact.personal.email",
                        "value": "user.test@gmail.com",
                        "isValid": true,
                        "isOwner": true
                    },
                    {
                        "label": "contact.personal.phoneNumber",
                        "value": "+1 555-618-7380",
                        "isValid": true,
                        "isOwner": true
                    }
                ]
```