### PR TITLE
CM-1830 Update jsrsasign to v10 because of audit vulnerabilities in v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "crypto-js": "^3.1.9-1",
     "json-stable-stringify": "^1.0.1",
-    "jsrsasign": "^7.1.5",
+    "jsrsasign": "^10.6.1",
     "jsrsasign-util": "^1.0.0",
     "lodash.merge": "^4.6.0",
     "promise": "^7.1.1",


### PR DESCRIPTION
Update jsrsasign to v10 because of audit vulnerabilities in v7